### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 is an awesome tool to build small web application. But once you start
 using it, you discover that writing the configuration and the routes
 often leads to ugly code. To solve that, Americano acts as a
-wrapper around Express and make it more opiniated about how to write routes
+wrapper around Express and make it more opinionated about how to write routes
 and configuration. See in the following how it make things cleaner.
 
 ## When to use Americano?
@@ -48,7 +48,7 @@ There is a binary provided with Americano to start quickly your project:
     create: blog/server/controllers
     create: blog/server/controllers/routes.coffee
     create: blog/server/controllers/index.coffee
-      
+
     install dependencies:
     $ cd blog && npm install
 
@@ -163,7 +163,7 @@ and more straightforward things.
 
 Actually there is only one plugin, feel free to add yours:
 
-* [americano-cozy](https://github.com/frankrousseau/americano-cozy): a plugin 
+* [americano-cozy](https://github.com/frankrousseau/americano-cozy): a plugin
 to make [Cozy](http://cozy.io) application faster.
 
 ## What about contributions?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "americano",
-  "description": "Wrapper for Express with an opiniated configuration.",
+  "description": "Wrapper for Express with an opinionated configuration.",
   "keywords": [
     "framework"
   ],


### PR DESCRIPTION
Opiniated -> Opinionated
ref: http://translate.google.com/?text=opinioinated#en/fr/opinionated

The github repository description should also be fixed.
