### PR TITLE
Plugin integration

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -131,8 +131,8 @@ americano._loadPlugins = (app, callback) ->
 americano._new = (callback) ->
     app = americano()
     americano._configure app
-    americano._loadRoutes app
     americano._loadPlugins app, ->
+        americano._loadRoutes app
         callback app
 
 


### PR DESCRIPTION
- plugin usage is now:
  Configuration:

``` coffeescript
#./server/config.coffee
plugins: [
    'an-americano-plugin'
]
```

Usage:

``` coffeescript
americano = require 'americano'
americano.pluginProperty()
```

There is no detection of eventual collision, maybe I can add a warning message if a collision is detected (would only require to rewrite the `extends` function, no big deal) ?
- we can specify absolute paths for plugins (to ease plugin development/debugging)
- in the "configure" method of plugins, you can use "this" as americano instance

Before merging, I think we could discuss the plugin configuration so I can add it to the PR.
To keep things simple this is what I propose:

``` coffeescript
plugins: [
    'plugin-name': 
        'configKey1': 'config value 1'
        'configKey2': 'config value 2'
    ]
```

Then we could change the "configure" plugin methods by adding the options:

```
coffeescript
module.exports.configure = (root, app, options, callback) ->
```

Tell me what you think and I will add the proper changes.
