### PR TITLE
Give the possibility to have several controllers for a single path by passing an array

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -90,7 +90,10 @@ americano._loadRoute = (app, path, verb, controller) ->
         if verb is "param"
             app.param path, controller
         else
-            app[verb] "/#{path}", controller
+            if controller instanceof Array
+                app[verb].apply app, ["/#{path}"].concat controller
+            else
+                app[verb] "/#{path}", controller
     catch err
         console.log "[ERROR] Can't load controller for " + \
                     "route #{verb} #{path} #{action}"


### PR DESCRIPTION
This allows to have the following scheme in routes.coffee:

```
module.exports =
    '':
        get: index.index
    'items':
        get: [index.isLoggedIn, index.all]
        delete: [index.isLoggedIn, index.delete]
```

which is equivalent to:

```
app.get 'items', index.isLoggedIn, index.all
app.delete 'items, index.isLoggedIn, index.delete
```

(FWIW, it means that Express will call first isLoggedIn, and only if isLoggedIn calls next(), it will call index.all, for the first example)
