### PR TITLE
Minor changes

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -170,7 +170,7 @@ americano.start = (options, callback) ->
         if app.beforeStart?
             app.beforeStart()
         server = app.listen port, host, ->
-            app.afterStart() if app.afterStart?
+            app.afterStart app, server if app.afterStart?
             log.info "Configuration for #{process.env.NODE_ENV} loaded."
             log.info "#{name} server is listening on " + \
                       "port #{port}..."


### PR DESCRIPTION
- Fixed: the default plugin path was relative to "root", therefore an application couldn't be started in a subfolder (e.g. "build/"). It doesn't break anything due to node module loading strategy: check the ./node_modules, if not found, check ../node_modules and so on (then it gets more complicated, not relevant here).
- Added: the afterStart hook had no parameter, the primary goal of this hook was to start things after server is started so those things could be bound to the server. app/server as parameters will solve that issue.
