### PR TITLE
Added: missing express compatibility trick in middleware loading

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -54,7 +54,9 @@ americano._configure = (app) ->
 americano._configureEnv = (app, env, middlewares) ->
     applyMiddlewares = ->
         if middlewares instanceof Array
-            app.use middleware for middleware in middlewares
+            for middleware in middlewares
+                middleware = [middleware] unless middleware instanceof Array
+                app.use.apply app, middleware
         else
             for method, elements of middlewares
                 if method in ['beforeStart', 'afterStart']


### PR DESCRIPTION
In express you can add a middleware in two ways:

``` coffeescript
app.use express.static __dirname + '/public_client/public', maxAge: 86400000
# or
app.use '/public', express.static __dirname + '/public_client/public', maxAge: 86400000
```

This PR enables the second way (used in the Cozic application).
