### PR TITLE
Upgraded to Express 4.x

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -15,12 +15,17 @@ module.exports = americano = express
 # root folder, required to find the configuration files
 root = process.cwd()
 
+# Re-bundle middlewares
+Object.defineProperty americano, 'bodyParser', value: require 'body-parser'
+Object.defineProperty americano, 'methodOverride',
+                                               value: require 'method-override'
+Object.defineProperty americano, 'errorHandler', value: require 'errorhandler'
+Object.defineProperty americano, 'logger', value: require 'morgan'
+
 # Default configuration, used if no configuration file is found.
 config =
     common: [
         americano.bodyParser()
-        americano.json()
-        americano.urlencoded()
         americano.methodOverride()
         americano.errorHandler
             dumpExceptions: true
@@ -81,7 +86,6 @@ americano._loadRoutes = (app) ->
                     "sure routes.(coffee|js) is located at the root of" + \
                     " the controllers folder."
         log.warn "No routes loaded"
-
     for path, controllers of routes
         for verb, controller of controllers
             americano._loadRoute app, path, verb, controller

--- a/package.json
+++ b/package.json
@@ -33,14 +33,18 @@
   },
   "main": "./main.js",
   "dependencies": {
-    "express": "3.4.6",
-    "commander": "2.0.0",
-    "mkdirp": "0.3.5",
-    "printit": "0.1.3"
+    "express": "4.4.0",
+    "commander": "2.2.0",
+    "mkdirp": "0.5.0",
+    "printit": "0.1.3",
+    "body-parser": "1.3.0",
+    "method-override": "2.0.0",
+    "errorhandler": "1.0.1",
+    "morgan": "1.1.1"
   },
   "devDependencies": {
     "coffee-script": "*",
-    "request-json": "0.4.1",
+    "request-json": "0.4.10",
     "chai": "*",
     "mocha": "*"
   },

--- a/tests/server/controllers/routes.coffee
+++ b/tests/server/controllers/routes.coffee
@@ -1,1 +1,4 @@
-module.exports = {}
+module.exports =
+    # routes must not be empty, otherwise Express crashes
+    # see https://github.com/visionmedia/express/issues/2159
+    'fakeroute': get: (req, res) ->


### PR DESCRIPTION
The changes are 90% backward compatible. 

There are 2 BC breaks introduced:
- file upload because we don't bundle a middleware capable of that anymore (multipart support has been removed from body-parser).
- fancy middleware usage (body-parser, method-override, logger, errorHandler are safe)
