### PR TITLE
Allow passing multiple parameters to app.use()

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -83,7 +83,11 @@ americano._configureEnv = (app, env, middlewares) ->
                 if method in ['beforeStart', 'afterStart']
                     app[method] = elements
                 else if method is 'use'
-                    app[method] element for element in elements
+                    for element in elements
+                        if element instanceof Array
+                            app[method] element[0], element[1]
+                        else
+                            app[method] element
                 else if method is 'useAfter'
                     afterMiddlewares.push element for element in elements
                 else


### PR DESCRIPTION
I just found myself in a case where I have to serve multiple static directories, each with a different path. [Express's documentation](https://expressjs.com/en/4x/api.html#app.use) tells us this can be done by passing the path as the first `app.use()` parameter:
```js
app.use('/static', express.static('public'))
```
This PR allows Americano's config to do just this. If a path must be added to the static directory, the `use` configuration shall look like this:
```js
use: [
    americano.bodyParser(),
    americano.methodOverride(),
    americano.static(__dirname + '/../../client/public', {
        maxAge: 86400000
    }),
    ['/static', americano.static(__dirname + '/../../testStatic', {
        maxAge: 86400000
    })]
]
```
In this example you can see how my `client/public` directory is being served statically without a path (so using the root), and my `testStatic` directory is being served statically on `/static`.